### PR TITLE
embedded resource files, GetResourcePath TemplateBase helper

### DIFF
--- a/Nocco/EmbeddedResources.cs
+++ b/Nocco/EmbeddedResources.cs
@@ -105,3 +105,4 @@ namespace Nocco
 		}
 	}
 }
+

--- a/Nocco/EmbeddedResources.cs
+++ b/Nocco/EmbeddedResources.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.CodeDom.Compiler;
+using System.IO;
+using System.Linq;
+using System.Web.Razor;
+using System.Text;
+
+namespace Nocco
+{
+	public class EmbeddedResources
+	{
+		Type templateType = null;
+		string[] clientFiles = { "prettify.js", "Nocco.css" };
+
+		public void WriteClientFilesTo(string path)
+		{
+			Directory.CreateDirectory(path);
+
+			foreach (string res in clientFiles)
+			{
+				string outputFile = Path.Combine(path, res);
+
+				// Don't overwrite existing resource files
+				if (File.Exists(outputFile))
+					continue;
+
+				try
+				{
+					using (var writer = File.CreateText(outputFile))
+					{
+						Stream s = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream("Nocco.Resources." + res);
+						if (s == null)
+							throw new InvalidDataException("Could not find embedded resource 'Nocco.Resources." + res + "'");
+
+						using (var reader = new StreamReader(s))
+						{
+							writer.Write(reader.ReadToEnd());
+						}
+					}
+				}
+				catch
+				{
+					try { File.Delete(outputFile); } catch { }
+				}
+			}
+		}
+
+		//### Template Setup
+
+		// Setup the Razor templating engine so that we can quickly pass the data in
+		// and generate HTML.
+		//
+		// The file `Resources\Nocco.cshtml` is read and compiled into a new dll
+		// with a type that extends the `TemplateBase` class. This new assembly is
+		// loaded so that we can create an instance and pass data into it
+		// and generate the HTML.
+		public TemplateBase CreateRazorTemplateInstance()
+		{
+			if (templateType == null)
+			{
+				var host = new RazorEngineHost(new CSharpRazorCodeLanguage());
+				host.DefaultBaseClass = typeof(TemplateBase).FullName;
+				host.DefaultNamespace = "RazorOutput";
+				host.DefaultClassName = "Template";
+				host.NamespaceImports.Add("System");
+
+				GeneratorResults razorResult = null;
+
+				var templateStream = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream("Nocco.Resources.Nocco.cshtml");
+
+				if (templateStream == null)
+					throw new FileNotFoundException("Could not find embedded resource 'Nocco.Resources.Nocco.cshtml'");
+
+				using (var reader = new StreamReader(templateStream))
+				{
+					razorResult = new RazorTemplateEngine(host).GenerateCode(reader);
+				}
+
+				var compilerParams = new CompilerParameters
+				{
+					GenerateInMemory = true,
+					GenerateExecutable = false,
+					IncludeDebugInformation = false,
+					CompilerOptions = "/target:library /optimize"
+				};
+				compilerParams.ReferencedAssemblies.Add(typeof(Program).Assembly.CodeBase.Replace("file:///", "").Replace('/', Path.DirectorySeparatorChar));
+
+				var codeProvider = new Microsoft.CSharp.CSharpCodeProvider();
+				var results = codeProvider.CompileAssemblyFromDom(compilerParams, razorResult.GeneratedCode);
+
+				// Check for errors that may have occurred during template generation
+				if (results.Errors.HasErrors)
+				{
+					StringBuilder errors = new StringBuilder();
+					foreach (var err in results.Errors.OfType<CompilerError>().Where(ce => !ce.IsWarning))
+						errors.AppendFormat("Error compiling template: ({0}, {1}) {2}", err.Line, err.Column, err.ErrorText);
+
+					throw new InvalidDataException(errors.ToString());
+				}
+
+				templateType = results.CompiledAssembly.GetType("RazorOutput.Template");
+			}
+
+			return (TemplateBase)Activator.CreateInstance(templateType);
+		}
+	}
+}

--- a/Nocco/Nocco.csproj
+++ b/Nocco/Nocco.csproj
@@ -35,6 +35,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="EmbeddedResources.cs" />
     <Compile Include="Language.cs" />
     <Compile Include="Nocco.cs" />
     <Compile Include="Program.cs" />
@@ -51,19 +52,19 @@
     <Reference Include="System.Web.Razor, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="Resources\prettify.js">
+    <EmbeddedResource Include="Resources\prettify.js">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    </EmbeddedResource>
     <None Include="app.config" />
     <None Include="packages.config" />
-    <Content Include="Resources\Nocco.cshtml">
+    <EmbeddedResource Include="Resources\Nocco.cshtml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="Resources\Nocco.css">
+    <EmbeddedResource Include="Resources\Nocco.css">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Nocco/Resources/Nocco.cshtml
+++ b/Nocco/Resources/Nocco.cshtml
@@ -4,8 +4,8 @@
 <head>
 	<title>@Title</title>
 	<meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-	<link href="@(PathToCss)" rel="stylesheet" media="all" type="text/css" />
-	<script src="prettify.js" type="text/javascript"></script>
+	<link href="@GetResourcePath("Nocco.css")" rel="stylesheet" media="all" type="text/css" />
+	<script src="@GetResourcePath("prettify.js")" type="text/javascript"></script>
 </head>
 <body onload="prettyPrint()">
 	<div id="container">

--- a/Nocco/TemplateBase.cs
+++ b/Nocco/TemplateBase.cs
@@ -11,6 +11,7 @@ namespace Nocco {
 		public string Title { get; set; }
 		public string PathToCss { get; set; }
 		public Func<string, string> GetSourcePath { get; set; }
+		public Func<string, string> GetResourcePath { get; set; }
 		public List<Section> Sections { get; set; }
 		public List<string> Sources { get; set; }
 


### PR DESCRIPTION
This pull request (1 of 2) is a feature that I think may be useful for Nocco. It stores the "Resources" folder as embedded resources in the binary and writes them to the destination folder.

Background: I recently forked Nocco to create something similar but which violates the "quick and dirty" lineage. I added a lexer/parser in order to find types and hyperlink them to the other source files. I also added line numbers and I'm in the process of changing the style and "jump" list. This contribution is part of the improvements I *think* I made to Nocco. You can take it or leave it.