### PR TITLE
Fixed so prettify.js is resolved with right url

### DIFF
--- a/Nocco/Nocco.cs
+++ b/Nocco/Nocco.cs
@@ -120,6 +120,7 @@ namespace Nocco {
 
 			htmlTemplate.Title = Path.GetFileName(source);
 			htmlTemplate.PathToCss = Path.Combine(pathToRoot, "nocco.css").Replace('\\', '/');
+		    htmlTemplate.PathToJs = Path.Combine(pathToRoot, "prettify.js").Replace('\\', '/');
 			htmlTemplate.GetSourcePath = (string s) => Path.Combine(pathToRoot, Path.ChangeExtension(s.ToLower(), ".html").Substring(2)).Replace('\\', '/');
 			htmlTemplate.Sections = sections;
 			htmlTemplate.Sources = Files;

--- a/Nocco/Resources/Nocco.cshtml
+++ b/Nocco/Resources/Nocco.cshtml
@@ -5,7 +5,7 @@
 	<title>@Title</title>
 	<meta http-equiv="content-type" content="text/html; charset=UTF-8" />
 	<link href="@(PathToCss)" rel="stylesheet" media="all" type="text/css" />
-	<script src="prettify.js" type="text/javascript"></script>
+	<script src="@(PathToJs)" type="text/javascript"></script>
 </head>
 <body onload="prettyPrint()">
 	<div id="container">

--- a/Nocco/TemplateBase.cs
+++ b/Nocco/TemplateBase.cs
@@ -10,6 +10,7 @@ namespace Nocco {
 		// Properties available from within the template
 		public string Title { get; set; }
 		public string PathToCss { get; set; }
+        public string PathToJs { get; set; }
 		public Func<string, string> GetSourcePath { get; set; }
 		public List<Section> Sections { get; set; }
 		public List<string> Sources { get; set; }


### PR DESCRIPTION
In the Nocco.cshtml template only the css file was being resolved
correctly. The prettify.js file was always assumed to be in the
same folder as the html file, which would fail when your generated
docs were stored in (the generated) sub-folders
