### PR TITLE
Let Nocco work in Linux (mono) environments

### DIFF
--- a/Nocco/Nocco.cs
+++ b/Nocco/Nocco.cs
@@ -160,7 +160,13 @@ namespace Nocco {
 				IncludeDebugInformation = false,
 				CompilerOptions = "/target:library /optimize"
 			};
-			compilerParams.ReferencedAssemblies.Add(typeof(Nocco).Assembly.CodeBase.Replace("file:///", "").Replace("/", "\\"));
+
+			// Use directory separator char to determine filesystem root i.e. "/" (Linux) vs. "" (Windows)
+			var filesystemRoot = "";
+			if (Path.DirectorySeparatorChar == '/') {
+				filesystemRoot = "/";
+			}
+			compilerParams.ReferencedAssemblies.Add(typeof(Nocco).Assembly.CodeBase.Replace("file:///", filesystemRoot).Replace("/", Path.DirectorySeparatorChar.ToString()));
 
 			var codeProvider = new Microsoft.CSharp.CSharpCodeProvider();
 			var results = codeProvider.CompileAssemblyFromDom(compilerParams, razorResult.GeneratedCode);


### PR DESCRIPTION
Hi dontangg,

  I had to remove the nuget.exe reference from the .sln file and let the monodevelop ide resolve the dependencies in addition to the change in this pull request with respect to directory separate characters.

  Works great for me! If this compiles and generates docs for you on Windows, than merge with confidence. :)

  Thanks for this C# port!
